### PR TITLE
並び順を更新順に変更

### DIFF
--- a/src/hooks/todoist/useTodoist.ts
+++ b/src/hooks/todoist/useTodoist.ts
@@ -62,13 +62,17 @@ export function useGetLabels() {
 }
 
 export async function updateTodoistTask(taskId: string, param: UpdateTaskArgs) {
-  const response = await api.updateTask(taskId, {
+  const cleanArgs = Object.fromEntries(
+  Object.entries({
     content: param.content,
     description: param.description,
     priority: param.priority,
     dueString: param.dueString,
     labels: param.labels,
-  });
+    dueDatetime: param.dueDatetime,
+  }).filter(([, v]) => v !== undefined)) as UpdateTaskArgs;
+
+  const response = await api.updateTask(taskId, cleanArgs);
   return response;
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -79,7 +79,7 @@ export default function Command() {
       {tasks && tasks.length > 0 && (
         <List.Section title="Tasks">
           {tasks
-            ?.sort((a: Task, b: Task) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+            ?.sort((a: Task, b: Task) => (b.due?.datetime ? new Date(b.due?.datetime).getTime() : 0) - (a.due?.datetime ? new Date(a.due?.datetime).getTime() : 0))
             .map((task) => (
               <List.Item
                 key={task.id}
@@ -94,7 +94,7 @@ export default function Command() {
                   <ActionPanel>
                     <Action
                       title="Start Toggl"
-                      onAction={() => startTogglTimer(task, todoistProjects, meData, togglProjects, refreshTimer)}
+                      onAction={() => startTogglTimer(task, todoistProjects, meData, togglProjects, refreshTimer, mutate)}
                       icon={{ source: Icon.Clock }}
                     />
                     <Action


### PR DESCRIPTION
タスクの並び順を更新順になるように変更しました。

更新順　→ Tooglで最近計測を行ったタスクが上にくる

## 具体的な実装
Todoistのdatetimeをスタート時に更新してソートするように変更しました。
